### PR TITLE
Fix ReceiverVerticleTracingTest#traceIsPropagated

### DIFF
--- a/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
+++ b/data-plane/receiver-loom/src/main/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducer.java
@@ -57,8 +57,7 @@ public class LoomKafkaProducer<K, V> implements ReactiveKafkaProducer<K, V> {
         final var ctxInt = ((ContextInternal) v.getOrCreateContext()).unwrap();
         if (ctxInt.tracer() != null) {
             this.tracer =
-                    new ProducerTracer(this.vertx.tracer(), TracingPolicy.PROPAGATE, "" /* TODO add bootrstrap servers */);
-//                    new ProducerTracer(ctxInt.tracer(), TracingPolicy.PROPAGATE, "" /* TODO add bootrstrap servers */);
+                    new ProducerTracer(ctxInt.tracer(), TracingPolicy.PROPAGATE, "" /* TODO add bootrstrap servers */);
         } else {
             this.tracer = null;
         }

--- a/data-plane/receiver-loom/src/test/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducerTest.java
+++ b/data-plane/receiver-loom/src/test/java/dev/knative/eventing/kafka/broker/receiverloom/LoomKafkaProducerTest.java
@@ -15,9 +15,7 @@
  */
 package dev.knative.eventing.kafka.broker.receiverloom;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -128,7 +126,6 @@ public class LoomKafkaProducerTest {
                 .onComplete(ar -> {
                     testContext.verify(() -> {
                         assertTrue(ar.succeeded());
-                        assertEquals(0, producer.getEventQueueSize());
                         assertFalse(producer.isSendFromQueueThreadAlive());
 
                         checkpoints.flag();


### PR DESCRIPTION
In Vert.x 4.5.1, there was a fix to use the OTel default context storage when the Vert.x context storage provider is not invoked on a Vert.x thread.
See https://github.com/eclipse-vertx/vertx-tracing/pull/72

Since `LoomKafkaProducer` invokes the tracer on a virtual thread (or a worker thread), the sending task must be wrapped with the OTel current context.
Otherwise, tracing data will be lost at this point.

OTel provides an `ExecutorService` that does just that, so this commit refactors the producer to use an executor service instead of a queue plus manual polling.

Important: note that with this implementation, a virtual thread is created for each record, which is different from sending them one after the other with a single thread.